### PR TITLE
Fixup markup for self-titled URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# BitAuth (in Clojure(Script))
+# BitAuth (in Clojure/ClojureScript)
 
 [![Clojars Project](http://clojars.org/bitauth/latest-version.svg)](http://clojars.org/bitauth)
 
-This is a Clojure/ClojureScript port of BitPay's bitauth protocol: [https://github.com/bitpay/bitauth](https://github.com/bitpay/bitauth)
+This is a Clojure/ClojureScript port of BitPay's bitauth protocol: https://github.com/bitpay/bitauth
 
 The goals of this project are as follows:
 


### PR DESCRIPTION
Otherwise the link is just pointing back to this README